### PR TITLE
Remove duplicate header reading logic from the IBM MQ connector

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "ibm.ibmmq"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Ballerina"]
 keywords = ["ibm-mq"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-ibm.ibmmq"
@@ -12,8 +12,8 @@ distribution = "2201.8.0"
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ibm.ibmmq-native"
-version = "0.1.2"
-path = "../native/build/libs/ibm.ibmmq-native-0.1.2.jar"
+version = "0.1.3"
+path = "../native/build/libs/ibm.ibmmq-native-0.1.3-SNAPSHOT.jar"
 
 [[platform.java17.dependency]]
 groupId = "org.json"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -21,19 +21,6 @@ modules = [
 
 [[package]]
 org = "ballerina"
-name = "io"
-version = "1.6.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "lang.value"}
-]
-modules = [
-	{org = "ballerina", packageName = "io", moduleName = "io"}
-]
-
-[[package]]
-org = "ballerina"
 name = "jballerina.java"
 version = "0.0.0"
 modules = [
@@ -43,15 +30,6 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "lang.error"
-version = "0.0.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
-]
-
-[[package]]
-org = "ballerina"
-name = "lang.value"
 version = "0.0.0"
 scope = "testOnly"
 dependencies = [
@@ -78,6 +56,9 @@ version = "2.4.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
+modules = [
+	{org = "ballerina", packageName = "time", moduleName = "time"}
+]
 
 [[package]]
 org = "ballerinax"
@@ -85,9 +66,9 @@ name = "ibm.ibmmq"
 version = "0.1.3"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
-	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "test"}
+	{org = "ballerina", name = "test"},
+	{org = "ballerina", name = "time"}
 ]
 modules = [
 	{org = "ballerinax", packageName = "ibm.ibmmq", moduleName = "ibm.ibmmq"}

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -21,6 +21,19 @@ modules = [
 
 [[package]]
 org = "ballerina"
+name = "io"
+version = "1.6.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.value"}
+]
+modules = [
+	{org = "ballerina", packageName = "io", moduleName = "io"}
+]
+
+[[package]]
+org = "ballerina"
 name = "jballerina.java"
 version = "0.0.0"
 modules = [
@@ -30,6 +43,15 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "lang.error"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
+name = "lang.value"
 version = "0.0.0"
 scope = "testOnly"
 dependencies = [
@@ -63,6 +85,7 @@ name = "ibm.ibmmq"
 version = "0.1.3"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
+	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "test"}
 ]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -56,9 +56,6 @@ version = "2.4.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
-modules = [
-	{org = "ballerina", packageName = "time", moduleName = "time"}
-]
 
 [[package]]
 org = "ballerinax"
@@ -67,8 +64,7 @@ version = "0.1.3"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "test"},
-	{org = "ballerina", name = "time"}
+	{org = "ballerina", name = "test"}
 ]
 modules = [
 	{org = "ballerinax", packageName = "ibm.ibmmq", moduleName = "ibm.ibmmq"}

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -63,7 +63,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "ibm.ibmmq"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/tests/queue_producer_consumer_tests.bal
+++ b/ballerina/tests/queue_producer_consumer_tests.bal
@@ -41,7 +41,7 @@ function basicQueueProducerConsumerTest() returns error? {
 @test:Config {
     groups: ["ibmmqQueue"]
 }
-function basicQueueProducerConsumerWithJsonTest() returns error? {
+function basicQueueProducerConsumerWithJsonPayloadTest() returns error? {
     QueueManager queueManager = check new (name = "QM1", host = "localhost", channel = "DEV.APP.SVRCONN");
     Queue producer = check queueManager.accessQueue("DEV.QUEUE.1", MQOO_OUTPUT);
     Queue consumer = check queueManager.accessQueue("DEV.QUEUE.1", MQOO_INPUT_AS_Q_DEF);

--- a/ballerina/tests/queue_producer_consumer_tests.bal
+++ b/ballerina/tests/queue_producer_consumer_tests.bal
@@ -54,9 +54,9 @@ function basicQueueProducerConsumerWithJsonTest() returns error? {
                     "LastName":"Sabthar"
                     },
                 "EmployeeFullName":"Mahroof   Sabthar",
-                "EmployeeSalary":1500.0,
+                "EmployeeSalary":1500.00d,
                 "EmployeeGrade":"A",
-                "EmployeeRating":99.8,
+                "EmployeeRating":99.8d,
                 "EmployeeDepartments":[
                     {
                         "DeptCode":20901,
@@ -71,8 +71,8 @@ function basicQueueProducerConsumerWithJsonTest() returns error? {
                     "Street":"Vijya Road",
                     "City":"Kolonnawa"
                 },
-                "FineAmount":100.0,
-                "PenaltyRating":9.2
+                "FineAmount":100.00d,
+                "PenaltyRating":9.2d
             }
         }
     };

--- a/ballerina/tests/queue_producer_consumer_tests.bal
+++ b/ballerina/tests/queue_producer_consumer_tests.bal
@@ -234,6 +234,80 @@ function produceAndConsumerMessageWithAdditionalPropertiesTest() returns error? 
     check queueManager.disconnect();
 }
 
+@test:Config {
+    groups: ["ibmmqQueue"]
+}
+function produceAndConsumerMessageWithAdditionalPropertiesWithJsonPayloadTest() returns error? {
+    QueueManager queueManager = check new (name = "QM1", host = "localhost", channel = "DEV.APP.SVRCONN");
+    Queue producer = check queueManager.accessQueue("DEV.QUEUE.1", MQOO_OUTPUT);
+    Queue consumer = check queueManager.accessQueue("DEV.QUEUE.1", MQOO_INPUT_AS_Q_DEF);
+    time:Utc timeNow = time:utcNow();
+    json messageBody = {
+        "data":{
+            "EmployeeRecord":{
+                "EmployeeId":"0001",
+                "EmployeeName":{
+                    "FirstName":"Mahroof",
+                    "LastName":"Sabthar"
+                    },
+                "EmployeeFullName":"Mahroof   Sabthar",
+                "EmployeeSalary":1500.00d,
+                "EmployeeGrade":"A",
+                "EmployeeRating":99.8d,
+                "EmployeeDepartments":[
+                    {
+                        "DeptCode":20901,
+                        "DeptName":"R&D"
+                    },{
+                        "DeptCode":29041,
+                        "DeptName":"Ballerina"
+                    }
+                ],
+                "EmployeeAddress":"Vijya RoadKolonnawa",
+                "EmployeeAddressRed":{
+                    "Street":"Vijya Road",
+                    "City":"Kolonnawa"
+                },
+                "FineAmount":100.00d,
+                "PenaltyRating":9.2d
+            }
+        }
+    };
+    byte[] payload = messageBody.toJsonString().toBytes();
+    check producer->put({
+        payload: payload,
+        correlationId: "1234".toBytes(),
+        expiry: timeNow[0],
+        format: "mqformat",
+        messageId: "test-id".toBytes(),
+        messageType: 2,
+        persistence: 0,
+        priority: 4,
+        putApplicationType: 28,
+        replyToQueueManagerName: "QM1",
+        replyToQueueName: "DEV.QUEUE.1"
+    });
+    Message? message = check consumer->get();
+    if message !is () {
+        string rawMessageBody = check string:fromBytes(message.payload);
+        json receivedMessage = check rawMessageBody.fromJsonString();
+        test:assertEquals(receivedMessage, messageBody);
+        test:assertEquals(message.expiry, timeNow[0]);
+        test:assertEquals(message.format, "mqformat");
+        test:assertEquals(message.messageType, 2);
+        test:assertEquals(message.persistence, 0);
+        test:assertEquals(message.priority, 4);
+        test:assertEquals(message.putApplicationType, 28);
+        test:assertEquals(message.replyToQueueManagerName, "QM1");
+        test:assertEquals(message.replyToQueueName, "DEV.QUEUE.1");
+    } else {
+        test:assertFail("Expected a value for message");
+    }
+    check producer->close();
+    check consumer->close();
+    check queueManager.disconnect();
+}
+
 
 @test:Config {
     groups: ["ibmmqQueue"]
@@ -268,6 +342,105 @@ function produceAndConsumerMessageWithMultipleHeaderTypesTest() returns error? {
     Message? message = check consumer->get();
     if message !is () {
         test:assertEquals(string:fromBytes(message.payload), "Hello World");
+        Header[]? headers = message.headers;
+        if headers is () {
+            test:assertFail("Expected MQCIH headers");
+        }
+        test:assertTrue(headers.length() == 3);
+        Header header = headers[0];
+        if header is MQCIH {
+            test:assertEquals(header.facility, "facility".toBytes());
+            test:assertEquals(header.'function, "test");
+            test:assertEquals(header.abendCode, "code");
+            test:assertEquals(header.authenticator, "authenti");
+        }
+        header = headers[1];
+        if header is MQRFH2 {
+            test:assertEquals(header.flags, 12);
+            test:assertEquals(header.fieldValues.get(["mcd", "Msd"]), {folder: "mcd", 'field: "Msd", value: "TestMcdValue"});
+            test:assertEquals(header.fieldValues.get(["jms", "Dlv"]), {folder: "jms", 'field: "Dlv", value: 134});
+            test:assertEquals(header.fieldValues.get(["mqps", "Ret"]), {folder: "mqps", 'field: "Ret", value: "1"});
+        }
+        header = headers[2];
+        if header is MQRFH {
+            test:assertEquals(header.flags, 15);
+            test:assertEquals(header.nameValuePairs, {"pair1": "value1", "pair2": "value2"});
+        }
+    } else {
+        test:assertFail("Expected a value for message");
+    }
+    check producer->close();
+    check consumer->close();
+    check queueManager.disconnect();
+}
+
+@test:Config {
+    groups: ["ibmmqQueue"]
+}
+function produceAndConsumerMessageWithMultipleHeaderTypesWithJsonPayloadTest() returns error? {
+    QueueManager queueManager = check new (name = "QM1", host = "localhost", channel = "DEV.APP.SVRCONN");
+    Queue producer = check queueManager.accessQueue("DEV.QUEUE.1", MQOO_OUTPUT);
+    Queue consumer = check queueManager.accessQueue("DEV.QUEUE.1", MQOO_INPUT_AS_Q_DEF);
+    json messageBody = {
+        "data":{
+            "EmployeeRecord":{
+                "EmployeeId":"0001",
+                "EmployeeName":{
+                    "FirstName":"Mahroof",
+                    "LastName":"Sabthar"
+                    },
+                "EmployeeFullName":"Mahroof   Sabthar",
+                "EmployeeSalary":1500.00d,
+                "EmployeeGrade":"A",
+                "EmployeeRating":99.8d,
+                "EmployeeDepartments":[
+                    {
+                        "DeptCode":20901,
+                        "DeptName":"R&D"
+                    },{
+                        "DeptCode":29041,
+                        "DeptName":"Ballerina"
+                    }
+                ],
+                "EmployeeAddress":"Vijya RoadKolonnawa",
+                "EmployeeAddressRed":{
+                    "Street":"Vijya Road",
+                    "City":"Kolonnawa"
+                },
+                "FineAmount":100.00d,
+                "PenaltyRating":9.2d
+            }
+        }
+    };
+    byte[] payload = messageBody.toJsonString().toBytes();
+    check producer->put({
+        payload: payload,
+        headers: [
+            {
+                facility: "facility".toBytes(),
+                'function: "test",
+                abendCode: "code",
+                authenticator: "authenti"
+            },
+            {
+                flags: 12,
+                fieldValues: table [
+                    {folder: "mcd", 'field: "Msd", value: "TestMcdValue"},
+                    {folder: "jms", 'field: "Dlv", value: 134},
+                    {folder: "mqps", 'field: "Ret", value: true}
+                ]
+            },
+            {
+                flags: 15,
+                nameValuePairs: {"pair1": "value1", "pair2": "value2"}
+            }
+        ]
+    });
+    Message? message = check consumer->get();
+    if message !is () {
+        string rawMessageBody = check string:fromBytes(message.payload);
+        json receivedMessage = check rawMessageBody.fromJsonString();
+        test:assertEquals(receivedMessage, messageBody);
         Header[]? headers = message.headers;
         if headers is () {
             test:assertFail("Expected MQCIH headers");

--- a/ballerina/tests/queue_producer_consumer_tests.bal
+++ b/ballerina/tests/queue_producer_consumer_tests.bal
@@ -77,7 +77,6 @@ function basicQueueProducerConsumerWithJsonTest() returns error? {
         }
     };
     byte[] payload = messageBody.toJsonString().toBytes();
-    io:println(payload.length());
     check producer->put({
         payload: payload
     });

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixes
+
+- [When decoding IBM MQ headers from the received IBM MQ message Ballerina IBM MQ connector accidentally passes through to the message payload](https://github.com/ballerina-platform/ballerina-library/issues/5819)
+
+## [0.1.2] - 2023-11-15
+
 ### Added
+
+- [Added support `MQIIH` headers in `ibmmq:Message`](https://github.com/ballerina-platform/ballerina-standard-library/issues/5730)
+
+## [0.1.1] - 2023-11-14
+
+### Added
+
 - [Added support `MQRFH2` headers in `ibmmq:Message`](https://github.com/ballerina-platform/ballerina-standard-library/issues/5730)
 - [Incorporate secure-socket configuration for ballerina IBM MQ connector](https://github.com/ballerina-platform/ballerina-library/issues/5741)
 

--- a/native/src/main/java/io/ballerina/lib/ibm.ibmmq/headers/HeaderUtils.java
+++ b/native/src/main/java/io/ballerina/lib/ibm.ibmmq/headers/HeaderUtils.java
@@ -20,8 +20,6 @@ package io.ballerina.lib.ibm.ibmmq.headers;
 
 import com.ibm.mq.MQMessage;
 import com.ibm.mq.headers.MQDataException;
-import com.ibm.mq.headers.MQIIH;
-import com.ibm.mq.headers.MQMD;
 import com.ibm.mq.headers.MQMD1;
 import com.ibm.mq.headers.MQMDE;
 import com.ibm.mq.headers.MQRMH;
@@ -47,22 +45,6 @@ public class HeaderUtils {
     public static void decodeUnSupportedHeaders(Runtime runtime, MQMessage msg,
                                                 ArrayList<BMap<BString, Object>> headers) throws IOException {
         int dataOffset = msg.getDataOffset();
-        try {
-            MQIIH mqiih = new MQIIH();
-            mqiih.read(msg);
-            MQRFH2Header.decodeHeader(runtime, msg, headers);
-            return;
-        } catch (MQDataException e) {
-            msg.seek(dataOffset);
-        }
-        try {
-            MQMD mqmd = new MQMD();
-            mqmd.read(msg);
-            MQRFH2Header.decodeHeader(runtime, msg, headers);
-            return;
-        } catch (MQDataException e) {
-            msg.seek(dataOffset);
-        }
         try {
             MQMD1 mqmd1 = new MQMD1();
             mqmd1.read(msg);


### PR DESCRIPTION
## Purpose
> $subject

Fixes: [#5819](https://github.com/ballerina-platform/ballerina-library/issues/5819)

MQMD header [1] is the default header which is set to every IBM MQ message and it is a part of the IBM MQ message itself (refer to the overview of IBM MQ message class [2]). Hence it is not required to re-read the MQMD header from the message as the relevant values are already available in the message itself. 

MQIIH header [3] is already supported by Ballerina IBM MQ connector and should not be considered as unsupported header in the IBM MQ connector. 

This PR removes both MQMD header reading logic and MQIIH header reading logic from `HeaderUtil.decodeUnSupportedHeaders` method as both headers are already processed by the time the code reaches this particular logic.

[1] - [https://www.ibm.com/docs/en/ibm-mq/9.3?topic=java-mqmd](https://www.ibm.com/docs/en/ibm-mq/9.3?topic=java-mqmd)
[2] - [https://www.ibm.com/docs/en/ibm-mq/9.3?topic=java-mqmessage](https://www.ibm.com/docs/en/ibm-mq/9.3?topic=java-mqmessage)
[3] - [https://www.ibm.com/docs/en/ibm-mq/9.3?topic=java-mqiih](https://www.ibm.com/docs/en/ibm-mq/9.3?topic=java-mqiih)

## Examples
N/A

## Checklist
- [X] Linked to an issue
- [x] Updated the changelog
- [X] Added tests
- [ ] ~Updated the spec~
- [ ] ~Checked native-image compatibility~
